### PR TITLE
Fix QTimer import in run_ui.py

### DIFF
--- a/run_ui.py
+++ b/run_ui.py
@@ -13,8 +13,8 @@ import tempfile
 import argparse
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QPushButton, QVBoxLayout, 
                             QWidget, QLabel, QTextEdit, QFrame, QSlider, QHBoxLayout,
-                            QTabWidget, QLineEdit, QTimer)
-from PyQt5.QtCore import Qt, pyqtSignal, QThread
+                            QTabWidget, QLineEdit)
+from PyQt5.QtCore import Qt, pyqtSignal, QThread, QTimer
 from PyQt5.QtGui import QFont, QImage, QPixmap
 from pyaudio import PyAudio, paFloat32
 


### PR DESCRIPTION
Fixes runtime error:

```
Traceback (most recent call last):
  File "/LLMVoX/run_ui.py", line 14, in <module>
    from PyQt5.QtWidgets import (QApplication, QMainWindow, QPushButton, QVBoxLayout,
ImportError: cannot import name 'QTimer' from 'PyQt5.QtWidgets' (/miniforge3/lib/python3.9/site-packages/PyQt5/QtWidgets.abi3.so)
```